### PR TITLE
Fix zender-wa template

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -1,5 +1,5 @@
 import { Output, Services } from "~templates-utils";
-import { Input } from "./meta";  // Importa la definición de nuestros campos
+import { Input } from "./meta"; // Importa la definición de nuestros campos
 
 export function generate(input: Input): Output {
   const services: Services = [];
@@ -8,32 +8,45 @@ export function generate(input: Input): Output {
   services.push({
     type: "app",
     data: {
-      serviceName: input.serviceName || "whatsapp-server",  // nombre identificador del servicio
+      serviceName: input.appServiceName || "whatsapp-server", // nombre identificador del servicio
       env: [
         `PCODE=${input.pcode}`,
-        `KEY=${input.key}`,
-        `PORT=${input.port || 443}`
+        `KEY=${input.licenseKey}`,
+        `PORT=${input.port || 443}`,
       ].join("\n"),
       source: {
         type: "image",
-        image: "ubuntu:22.04"
+        image: "ubuntu:22.04",
       },
       // Comando de despliegue: instala wget/unzip, descarga el servidor WA y lo ejecuta
       deploy: {
-        command: 
+        command:
           `sh -c "apt-get update && apt-get install -y wget unzip && ` +
           `wget --no-cache https://raw.anycdn.link/wa/linux.zip && ` +
           `unzip -o linux.zip && chmod -R 777 . && chmod +x ./titansys-whatsapp-linux && rm linux.zip && ` +
-          `exec ./titansys-whatsapp-linux --pcode=$PCODE --key=$KEY --host=0.0.0.0 --port=$PORT"`
+          `exec ./titansys-whatsapp-linux --pcode=$PCODE --key=$KEY --host=0.0.0.0 --port=$PORT"`,
       },
+      domains: [
+        {
+          host: "$(EASYPANEL_DOMAIN)",
+          port: input.port || 443,
+        },
+      ],
+      mounts: [
+        {
+          type: "volume",
+          name: "data",
+          mountPath: "/app/data/whatsapp-server",
+        },
+      ],
       // Publicar el puerto para acceso externo o desde la app Zender
       ports: [
         {
-          published: input.port || 443,   // puerto host (por defecto 443)
-          target: input.port || 443       // puerto contenedor donde escucha la app
-        }
-      ]
-    }
+          published: input.port || 443, // puerto host (por defecto 443)
+          target: input.port || 443, // puerto contenedor donde escucha la app
+        },
+      ],
+    },
   });
 
   return { services };

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -21,10 +21,15 @@ contributors:
 schema:
   type: object
   required:
+    - appServiceName
     - pcode
     - licenseKey
     - port
   properties:
+    appServiceName:
+      type: string
+      title: App Service Name
+      default: zender-wa
     pcode:
       type: string
       title: Product Code (pcode)


### PR DESCRIPTION
## Summary
- allow specifying service name
- ensure env variables use the license key
- expose port and domain settings
- mount a volume for persistent sessions

## Testing
- `npm run prettier` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e36dd4f083328f6801a0c735cce6