### PR TITLE
Fix zender-wa template deploy script

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -1,5 +1,5 @@
 import { Output, Services } from "~templates-utils";
-import { Input } from "./meta";  // Importa la definición de nuestros campos
+import { Input } from "./meta"; // Importa la definición de nuestros campos
 
 export function generate(input: Input): Output {
   const services: Services = [];
@@ -8,32 +8,54 @@ export function generate(input: Input): Output {
   services.push({
     type: "app",
     data: {
-      serviceName: input.serviceName || "whatsapp-server",  // nombre identificador del servicio
+      serviceName: input.appServiceName || "whatsapp-server", // nombre identificador del servicio
       env: [
         `PCODE=${input.pcode}`,
-        `KEY=${input.key}`,
-        `PORT=${input.port || 443}`
+        `KEY=${input.licenseKey}`,
+        `PORT=${input.port || 443}`,
       ].join("\n"),
       source: {
         type: "image",
-        image: "ubuntu:22.04"
+        image: "ubuntu:22.04",
       },
-      // Comando de despliegue: instala wget/unzip, descarga el servidor WA y lo ejecuta
+      // Comando de despliegue: instala dependencias y configura un cron para mantener el servicio activo
       deploy: {
-        command: 
-          `sh -c "apt-get update && apt-get install -y wget unzip && ` +
+        command:
+          `sh -c "apt-get update && apt-get install -y wget unzip cron && ` +
+          `mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && ` +
           `wget --no-cache https://raw.anycdn.link/wa/linux.zip && ` +
-          `unzip -o linux.zip && chmod -R 777 . && chmod +x ./titansys-whatsapp-linux && rm linux.zip && ` +
-          `exec ./titansys-whatsapp-linux --pcode=$PCODE --key=$KEY --host=0.0.0.0 --port=$PORT"`
+          `unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && ` +
+          `cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n` +
+          `#!/bin/bash\n` +
+          `cd /app/data/whatsapp-server\n` +
+          `if ! pgrep -f titansys-whatsapp-linux > /dev/null; then\n` +
+          `  ./titansys-whatsapp-linux --pcode=\$PCODE --key=\$KEY --host=0.0.0.0 --port=\$PORT &\n` +
+          `fi\n` +
+          `EOF && chmod +x /usr/local/bin/run-whatsapp.sh && ` +
+          `(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && ` +
+          `cron && sleep infinity"`,
       },
+      domains: [
+        {
+          host: "$(EASYPANEL_DOMAIN)",
+          port: input.port || 443,
+        },
+      ],
+      mounts: [
+        {
+          type: "volume",
+          name: "data",
+          mountPath: "/app/data/whatsapp-server",
+        },
+      ],
       // Publicar el puerto para acceso externo o desde la app Zender
       ports: [
         {
-          published: input.port || 443,   // puerto host (por defecto 443)
-          target: input.port || 443       // puerto contenedor donde escucha la app
-        }
-      ]
-    }
+          published: input.port || 443, // puerto host (por defecto 443)
+          target: input.port || 443, // puerto contenedor donde escucha la app
+        },
+      ],
+    },
   });
 
   return { services };

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -8,6 +8,8 @@ instructions: null
 changeLog:
   - date: 2025-06-29
     description: Initial release of Zender WA EasyPanel template
+  - date: 2025-06-30
+    description: Fix deploy command and add cron job with sleep infinity
 links:
   - label: Website
     url: https://titansystems.ph
@@ -21,10 +23,15 @@ contributors:
 schema:
   type: object
   required:
+    - appServiceName
     - pcode
     - licenseKey
     - port
   properties:
+    appServiceName:
+      type: string
+      title: App Service Name
+      default: zender-wa
     pcode:
       type: string
       title: Product Code (pcode)


### PR DESCRIPTION
## Summary
- improve the deploy command so it installs cron and keeps the WhatsApp server running
- ensure permissions are set correctly and add a cron job to restart it if needed
- document the change in meta.yaml

## Testing
- `npm run build` *(fails: ts-node not found)*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_6862e36dd4f083328f6801a0c735cce6