### PR TITLE
Fix duplicate lines in Zender WA deploy

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -40,11 +40,7 @@ EOF\
           /usr/local/bin/run-whatsapp.sh && \
           (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && \
           cron && sleep infinity"`,
-chmod +x /usr/local/bin/run-whatsapp.sh && \
-/usr/local/bin/run-whatsapp.sh && \
-(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && \
-cron && sleep infinity"`,
-      },
+        },
       domains: [
         {
           host: "$(EASYPANEL_DOMAIN)",


### PR DESCRIPTION
## Summary
- fix `templates/zender-wa/index.ts` by removing leftover command lines that appeared after closing the deploy string

## Testing
- `npm run build-templates` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f33257788332bf1ec7fb35494350