### PR TITLE
Use curl for WA server download

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -20,9 +20,9 @@ export function generate(input: Input): Output {
       },
       // Deploy command: install dependencies and set up a cron job to keep the service running
       deploy: {
-        command: `sh -c "apt-get update && apt-get install -y wget unzip cron && \
+        command: `sh -c "apt-get update && apt-get install -y wget curl unzip cron && \
           mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
-          wget --no-cache https://convo.chat/wa/linux.zip && \
+          curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
           wget -O /usr/local/bin/install-wa.sh https://raw.githubusercontent.com/RenatoAscencio/zender-wa-deploy/refs/heads/main/install-wa.sh && \
           wget -O /usr/local/bin/restart-wa.sh https://raw.githubusercontent.com/RenatoAscencio/zender-wa-deploy/refs/heads/main/restart-wa.sh && \

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,15 +1,17 @@
 name: zender-wa
 title: WhatsApp Server (Zender)
-version: "1.0.0"
+version: "1.0.1"
 description: >
-  Deploys the Titan Systems (Zender) WhatsApp server with session persistence
-  to keep the login state between restarts.
+  Deploys the Titan Systems (Zender) WhatsApp server with session persistence to
+  keep the login state between restarts.
 instructions: null
 changeLog:
   - date: 2025-06-29
     description: Initial release of Zender WA EasyPanel template
   - date: 2025-06-30
     description: Fix deploy command and add cron job with sleep infinity
+  - date: 2025-07-01
+    description: Use curl to download WA server binary
 links:
   - label: Website
     url: https://titansystems.ph
@@ -40,7 +42,9 @@ schema:
     licenseKey:
       type: string
       title: Secret Key
-      description: Unique secure secret key. This will be used by the WhatsApp server to verify peer connection with Zender.
+      description:
+        Unique secure secret key. This will be used by the WhatsApp server to
+        verify peer connection with Zender.
     port:
       type: integer
       title: TCP Port
@@ -57,7 +61,7 @@ features:
   - title: Directory management
     description: Uses a volume mounted at /app/data/whatsapp-server.
   - title: Automatic update
-    description: Downloads the latest server version on each deploy.
+    description: Downloads the latest server version using curl on each deploy.
 tags:
   - WhatsApp
   - Zender


### PR DESCRIPTION
## Summary
- use `curl` to download linux.zip for Zender WhatsApp server
- install curl package and document the change

## Testing
- `npm run build-templates` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863017211208332988011eaec4c5c63