### PR TITLE
Clone helper repo and store scripts in /app

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -20,25 +20,15 @@ export function generate(input: Input): Output {
       },
       // Deploy command: install dependencies and set up a cron job to keep the service running
       deploy: {
-        command: `sh -c "apt-get update && apt-get install -y wget unzip cron && \
+        command: `sh -c "apt-get update && apt-get install -y wget curl git unzip cron && \
           mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
-          wget --no-cache https://convo.chat/wa/linux.zip && \
+          curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
-          wget -O /usr/local/bin/install-wa.sh https://raw.githubusercontent.com/RenatoAscencio/zender-wa-deploy/refs/heads/main/install-wa.sh && \
-          wget -O /usr/local/bin/restart-wa.sh https://raw.githubusercontent.com/RenatoAscencio/zender-wa-deploy/refs/heads/main/restart-wa.sh && \
-          wget -O /usr/local/bin/update-wa.sh https://raw.githubusercontent.com/RenatoAscencio/zender-wa-deploy/refs/heads/main/update-wa.sh && \
-          chmod +x /usr/local/bin/install-wa.sh /usr/local/bin/restart-wa.sh /usr/local/bin/update-wa.sh && \
-          cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
-#!/bin/bash\n\
-cd /app/data/whatsapp-server\n\
-if ! pgrep -f titansys-whatsapp-linux > /dev/null; then\n\
-  ./titansys-whatsapp-linux --pcode=\$PCODE --key=\$KEY --host=0.0.0.0 --port=\$PORT &\n\
-fi\n\
-EOF\
-          chmod +x /usr/local/bin/run-whatsapp.sh && \
-          /usr/local/bin/install-wa.sh && \
-          /usr/local/bin/run-whatsapp.sh && \
-          (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && \
+          git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /data && \
+          cp /data/*.sh /app/ && chmod +x /app/*.sh && \
+          /app/install-wa.sh && \
+          /app/restart-wa.sh && \
+          (crontab -l 2>/dev/null; echo "* * * * * /app/restart-wa.sh") | crontab - && \
           cron && sleep infinity"`,
       },
       domains: [

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,15 +1,25 @@
 name: zender-wa
 title: WhatsApp Server (Zender)
-version: "1.0.0"
+version: "1.0.5"
 description: >
-  Deploys the Titan Systems (Zender) WhatsApp server with session persistence
-  to keep the login state between restarts.
+  Deploys the Titan Systems (Zender) WhatsApp server with session persistence to
+  keep the login state between restarts.
 instructions: null
 changeLog:
   - date: 2025-06-29
     description: Initial release of Zender WA EasyPanel template
   - date: 2025-06-30
     description: Fix deploy command and add cron job with sleep infinity
+  - date: 2025-07-01
+    description: Use curl to download WA server binary
+  - date: 2025-07-01
+    description: Use curl to download helper scripts from GitHub
+  - date: 2025-07-02
+    description: Clone helper repo to /data and run install script from there
+  - date: 2025-07-03
+    description: Clone helper repo using HTTPS to avoid host key verification
+  - date: 2025-07-04
+    description: Use restart-wa.sh from helper repo for cron job
 links:
   - label: Website
     url: https://titansystems.ph
@@ -40,7 +50,9 @@ schema:
     licenseKey:
       type: string
       title: Secret Key
-      description: Unique secure secret key. This will be used by the WhatsApp server to verify peer connection with Zender.
+      description:
+        Unique secure secret key. This will be used by the WhatsApp server to
+        verify peer connection with Zender.
     port:
       type: integer
       title: TCP Port
@@ -57,7 +69,7 @@ features:
   - title: Directory management
     description: Uses a volume mounted at /app/data/whatsapp-server.
   - title: Automatic update
-    description: Downloads the latest server version on each deploy.
+    description: Downloads the latest server version using curl on each deploy.
 tags:
   - WhatsApp
   - Zender


### PR DESCRIPTION
## Summary
- clone the zender-wa-deploy repo into `/data`
- copy helper scripts to `/app` and run `install-wa.sh`
- add `git` to dependency list
- use HTTPS to avoid host key verification errors
- use `restart-wa.sh` from helper repo for cron job
- bump template version to 1.0.5

## Testing
- `npm run build-templates` *(fails: ts-node not found)*


------
https://chatgpt.com/codex/tasks/task_e_6863017211208332988011eaec4c5c63