### PR TITLE
Fix zender-wa clone link

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -24,7 +24,7 @@ export function generate(input: Input): Output {
           mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
           curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
-          git clone git@github.com:RenatoAscencio/zender-wa-deploy.git /data && \
+          git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /data && \
           cp /data/*.sh /app/ && chmod +x /app/*.sh && \
           cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
 #!/bin/bash\n\


### PR DESCRIPTION
## Summary
- use HTTPS for zender-wa helper repo

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631365d6ec8332b2e24090e7858764