### PR TITLE
Add optional domain and fix zender-wa helper download

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -20,12 +20,12 @@ export function generate(input: Input): Output {
       },
       // Deploy command: install dependencies and set up a cron job to keep the service running
       deploy: {
-        command: `sh -c "apt-get update && apt-get install -y wget curl git unzip cron && \
+        command: `sh -c "apt-get update && apt-get install -y wget curl unzip cron && \
           mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
           curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
-          git clone git@github.com:RenatoAscencio/zender-wa-deploy.git /data && \
-          cp /data/*.sh /app/ && chmod +x /app/*.sh && \
+          curl -L -o deploy.zip https://github.com/RenatoAscencio/zender-wa-deploy/archive/refs/heads/main.zip && \
+          unzip -o deploy.zip && cp zender-wa-deploy-*/*.sh /app/ && chmod +x /app/*.sh && rm -rf deploy.zip zender-wa-deploy-* && \
           cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
 #!/bin/bash\n\
 cd /app/data/whatsapp-server\n\
@@ -41,7 +41,7 @@ EOF\
       },
       domains: [
         {
-          host: "$(EASYPANEL_DOMAIN)",
+          host: input.domain || "$(EASYPANEL_DOMAIN)",
           port: input.port || 443,
         },
       ],

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -54,6 +54,11 @@ schema:
       title: TCP Port
       description: Port where the WhatsApp server will listen.
       default: 443
+    domain:
+      type: string
+      title: Domain
+      description: >
+        Domain to expose the WhatsApp server. Defaults to your EasyPanel domain if not provided.
 benefits:
   - title: Session persistence
     description: Keeps WhatsApp sessions active between restarts.


### PR DESCRIPTION
## Summary
- add optional `domain` input in `zender-wa` template
- download helper scripts via `curl` instead of `git`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build-templates` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631365d6ec8332b2e24090e7858764