### PR TITLE
Fix git not found in zender-wa

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -20,7 +20,7 @@ export function generate(input: Input): Output {
       },
       // Deploy command: install dependencies and set up a cron job to keep the service running
       deploy: {
-        command: `sh -c "apt-get update && apt-get install -y wget curl unzip cron && \
+        command: `sh -c "apt-get update && apt-get install -y wget curl git unzip cron && \
           mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
           curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,6 +1,6 @@
 name: zender-wa
 title: WhatsApp Server (Zender)
-version: "1.0.3"
+version: "1.0.4"
 description: >
   Deploys the Titan Systems (Zender) WhatsApp server with session persistence to
   keep the login state between restarts.
@@ -18,6 +18,8 @@ changeLog:
     description: Clone helper repo to /data and run install script from there
   - date: 2025-07-03
     description: Clone helper repo via HTTPS and install git
+  - date: 2025-07-04
+    description: Ensure git is installed during deployment
 links:
   - label: Website
     url: https://titansystems.ph
@@ -60,7 +62,8 @@ schema:
       type: string
       title: Domain
       description: >
-        Domain to expose the WhatsApp server. Defaults to your EasyPanel domain if not provided.
+        Domain to expose the WhatsApp server. Defaults to your EasyPanel domain
+        if not provided.
 benefits:
   - title: Session persistence
     description: Keeps WhatsApp sessions active between restarts.
@@ -68,7 +71,8 @@ benefits:
     description: Crontab ensures the server restarts if it fails.
 features:
   - title: Dependency installation
-    description: Updates the system and installs wget, curl, git, unzip and cron.
+    description:
+      Updates the system and installs wget, curl, git, unzip and cron.
   - title: Directory management
     description: Uses a volume mounted at /app/data/whatsapp-server.
   - title: Automatic update


### PR DESCRIPTION
## Summary
- ensure git is installed when deploying the zender-wa template
- bump template version to 1.0.4
- document the fix in the changelog

## Testing
- `npm run build` *(fails: ts-node not found)*
- `npm run prettier`


------
https://chatgpt.com/codex/tasks/task_e_68631a36cb0483329e25535db9c355bf