### PR TITLE
Fix zender-wa git files not loaded

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -25,13 +25,8 @@ export function generate(input: Input): Output {
           curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
 
-          git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /data && \
-          cp /data/*.sh /app/ && chmod +x /app/*.sh && \
-
-
-          curl -L -o deploy.zip https://github.com/RenatoAscencio/zender-wa-deploy/archive/refs/heads/main.zip && \
-          unzip -o deploy.zip && cp zender-wa-deploy-*/*.sh /app/ && chmod +x /app/*.sh && rm -rf deploy.zip zender-wa-deploy-* && \
-
+          git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /app && \
+          chmod +x /app/*.sh && \
 
           cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
 #!/bin/bash\n\

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,6 +1,6 @@
 name: zender-wa
 title: WhatsApp Server (Zender)
-version: "1.0.4"
+version: "1.0.5"
 description: >
   Deploys the Titan Systems (Zender) WhatsApp server with session persistence to
   keep the login state between restarts.
@@ -20,6 +20,8 @@ changeLog:
     description: Clone helper repo via HTTPS and install git
   - date: 2025-07-04
     description: Ensure git is installed during deployment
+  - date: 2025-07-05
+    description: Clone helper repo directly to /app to keep git files
 links:
   - label: Website
     url: https://titansystems.ph


### PR DESCRIPTION
## Summary
- ensure helper repo is cloned directly into /app so that git metadata is available
- bump template version to 1.0.5

## Testing
- `npm run prettier`
- `npm run build` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632e2552e48332ba94d02d40dde86e