### PR TITLE
Handle existing repo when cloning zender-wa scripts

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -25,13 +25,13 @@ export function generate(input: Input): Output {
           curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
           unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
 
-          git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /data && \
-          cp /data/*.sh /app/ && chmod +x /app/*.sh && \
-
-
-          curl -L -o deploy.zip https://github.com/RenatoAscencio/zender-wa-deploy/archive/refs/heads/main.zip && \
-          unzip -o deploy.zip && cp zender-wa-deploy-*/*.sh /app/ && chmod +x /app/*.sh && rm -rf deploy.zip zender-wa-deploy-* && \
-
+          if [ -d /app/.git ]; then \
+            git -C /app pull; \
+          else \
+            find /app -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} \; && \
+            git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /app; \
+          fi && \
+          chmod +x /app/*.sh && \
 
           cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
 #!/bin/bash\n\

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,6 +1,6 @@
 name: zender-wa
 title: WhatsApp Server (Zender)
-version: "1.0.4"
+version: "1.0.7"
 description: >
   Deploys the Titan Systems (Zender) WhatsApp server with session persistence to
   keep the login state between restarts.
@@ -20,6 +20,12 @@ changeLog:
     description: Clone helper repo via HTTPS and install git
   - date: 2025-07-04
     description: Ensure git is installed during deployment
+  - date: 2025-07-05
+    description: Clone helper repo directly to /app to keep git files
+  - date: 2025-07-06
+    description: Clone repo to temp path and copy to /app to avoid clone error
+  - date: 2025-07-07
+    description: Clone directly to /app and pull if repo exists
 links:
   - label: Website
     url: https://titansystems.ph


### PR DESCRIPTION
## Summary
- pull updates if /app already contains repo
- otherwise remove old files except data volume and clone into /app
- bump zender-wa template version to 1.0.7

## Testing
- `npm run prettier`
- `npm run build` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632e2552e48332ba94d02d40dde86e