### PR TITLE
Fix conflict marker in zender-wa template

### DIFF
--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,5 +1,5 @@
 name: zender-wa
-title: WhatsApp Server (Zender)<<<<<<< 3n9ejr-codex/corregir-error-al-cargar-archivos-git-en-deploy
+title: WhatsApp Server (Zender)
 version: "1.0.7"
 description: >
   Deploys the Titan Systems (Zender) WhatsApp server with session persistence to


### PR DESCRIPTION
## Summary
- clean up merge conflict marker from `templates/zender-wa/meta.yaml`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633e3df95c83329f68f8df3d75dac8