### PR TITLE
Fix conflict marker and deploy script

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -40,7 +40,7 @@ cd /app/data/whatsapp-server\n\
 if ! pgrep -f titansys-whatsapp-linux > /dev/null; then\n\
   ./titansys-whatsapp-linux --pcode=\$PCODE --key=\$KEY --host=0.0.0.0 --port=\$PORT &\n\
 fi\n\
-EOF\
+EOF\n\
           chmod +x /usr/local/bin/run-whatsapp.sh && \
           /app/install-wa.sh && \
           /usr/local/bin/run-whatsapp.sh && \

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -1,5 +1,5 @@
 name: zender-wa
-title: WhatsApp Server (Zender)<<<<<<< 3n9ejr-codex/corregir-error-al-cargar-archivos-git-en-deploy
+title: WhatsApp Server (Zender)
 version: "1.0.7"
 description: >
   Deploys the Titan Systems (Zender) WhatsApp server with session persistence to


### PR DESCRIPTION
## Summary
- clean merge markers in `templates/zender-wa/meta.yaml`
- close here-doc correctly in `templates/zender-wa/index.ts`
- agrega salto de línea al finalizar el `cat` para evitar error de sintaxis

## Testing
- `npm run lint` *(falla: `next` no encontrado)*


------
https://chatgpt.com/codex/tasks/task_e_68633e3df95c83329f68f8df3d75dac8