### PR TITLE
Fix Zender WA template command

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -20,32 +20,30 @@ export function generate(input: Input): Output {
       },
       // Deploy command: install dependencies and set up a cron job to keep the service running
       deploy: {
-        command: `sh -c "apt-get update && apt-get install -y wget curl git unzip cron && \
-          mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
-          curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
-          unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
-
-          if [ -d /app/.git ]; then \
-            git -C /app pull; \
-          else \
-            find /app -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} \; && \
-            git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /app; \
-          fi && \
-
-          chmod +x /app/*.sh && \
-
-          cat <<'EOF' > /usr/local/bin/run-whatsapp.sh\n\
-#!/bin/bash\n\
-cd /app/data/whatsapp-server\n\
-if ! pgrep -f titansys-whatsapp-linux > /dev/null; then\n\
-  ./titansys-whatsapp-linux --pcode=\$PCODE --key=\$KEY --host=0.0.0.0 --port=\$PORT &\n\
-fi\n\
-EOF\n\
-          chmod +x /usr/local/bin/run-whatsapp.sh && \
-          /app/install-wa.sh && \
-          /usr/local/bin/run-whatsapp.sh && \
-          (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && \
-          cron && sleep infinity"`,
+        command: `sh -c "
+apt-get update && apt-get install -y wget curl git unzip cron && \
+mkdir -p /app/data/whatsapp-server && cd /app/data/whatsapp-server && \
+curl -L -o linux.zip https://convo.chat/wa/linux.zip && \
+unzip -o linux.zip && chmod +x titansys-whatsapp-linux && rm linux.zip && \
+if [ -d /app/.git ]; then \
+  git -C /app pull; \
+else \
+  find /app -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} \; && \
+  git clone https://github.com/RenatoAscencio/zender-wa-deploy.git /app; \
+fi && \
+chmod +x /app/*.sh && \
+cat <<'EOF' > /usr/local/bin/run-whatsapp.sh
+#!/bin/bash
+cd /app/data/whatsapp-server
+if ! pgrep -f titansys-whatsapp-linux > /dev/null; then
+  ./titansys-whatsapp-linux --pcode=\$PCODE --key=\$KEY --host=0.0.0.0 --port=\$PORT &
+fi
+EOF
+chmod +x /usr/local/bin/run-whatsapp.sh && \
+/app/install-wa.sh && \
+/usr/local/bin/run-whatsapp.sh && \
+(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/run-whatsapp.sh") | crontab - && \
+cron && sleep infinity"`,
       },
       domains: [
         {


### PR DESCRIPTION
## Summary
- fix shell command formatting for zender-wa template

## Testing
- `npx prettier -c templates/zender-wa/index.ts templates/zender-wa/meta.yaml`
- `npm run build` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863576609148332b39f43ea1017f44e