### PR TITLE
Add Docker image field to zender-wa template

### DIFF
--- a/templates/zender-wa/index.ts
+++ b/templates/zender-wa/index.ts
@@ -15,7 +15,7 @@ export function generate(input: Input): Output {
       ].join("\n"),
       source: {
         type: "image",
-        image: "renatoascencio/zender-wa:latest",
+        image: input.image || "renatoascencio/zender-wa:latest",
       },
       domains: [
         {

--- a/templates/zender-wa/meta.yaml
+++ b/templates/zender-wa/meta.yaml
@@ -73,6 +73,11 @@ schema:
       description: >
         Domain to expose the WhatsApp server. Defaults to your EasyPanel domain
         if not provided.
+    image:
+      type: string
+      title: Docker Image
+      description: Docker image to use for the WhatsApp server.
+      default: renatoascencio/zender-wa:latest
 benefits:
   - title: Session persistence
     description: Keeps WhatsApp sessions active between restarts.


### PR DESCRIPTION
## Summary
- add `image` field with default `renatoascencio/zender-wa:latest` to `zender-wa` template schema
- allow overriding the docker image in `index.ts`

## Testing
- `npm run build` *(fails: ENETUNREACH when patching lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68688434db788332a92bb0a6ef48cca1